### PR TITLE
Updates to 1.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,9 @@
 		<java.version>16</java.version>
 		<powermock.version>1.7.4</powermock.version>
 		<!-- More visible way how to change dependency versions -->
-		<spigot.version>1.17-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.17.1-R0.1-SNAPSHOT</spigot.version>
 		<bentobox.version>1.17.0</bentobox.version>
 		<level.version>2.5.0</level.version>
-		<lib.version>1.1.0</lib.version>
 		<!-- Revision variable removes warning about dynamic version -->
 		<revision>${build.version}-SNAPSHOT</revision>
 		<!-- This allows to change between versions and snapshots. -->
@@ -144,6 +143,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot</artifactId>
+			<version>${spigot.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.spigotmc</groupId>
 			<artifactId>plugin-annotations</artifactId>
 			<version>1.2.3-SNAPSHOT</version>
 		</dependency>
@@ -165,13 +170,13 @@
 		<dependency>
 			<groupId>io.github.iltotore</groupId>
 			<artifactId>customentity</artifactId>
-			<version>${lib.version}</version>
+			<version>1.1.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_17_r1</artifactId>
-			<version>${lib.version}</version>
+			<version>1.1.1</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<!-- Revision variable removes warning about dynamic version -->
 		<revision>${build.version}-SNAPSHOT</revision>
 		<!-- This allows to change between versions and snapshots. -->
-		<build.version>1.1.0</build.version>
+		<build.version>1.2.0</build.version>
 		<build.number>-LOCAL</build.number>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 		<dependency>
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_17_r1</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.5</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/lv/id/bonne/dragonfights/DragonFightsAddon.java
+++ b/src/main/java/lv/id/bonne/dragonfights/DragonFightsAddon.java
@@ -87,15 +87,23 @@ public class DragonFightsAddon extends Addon
 		if (this.hooked)
 		{
 			this.setupAddon();
-
-			// Load data about existing battles.
-			this.addonManager.load();
 		}
 		else
 		{
 			this.logError("Dragon Fights could not hook into any GameMode.");
 			this.setState(State.DISABLED);
 		}
+	}
+
+
+	/**
+	 * Load dragons when everything is loaded.
+	 */
+	@Override
+	public void allLoaded()
+	{
+		super.allLoaded();
+		this.addonManager.load();
 	}
 
 

--- a/src/main/java/lv/id/bonne/dragonfights/managers/DragonFightManager.java
+++ b/src/main/java/lv/id/bonne/dragonfights/managers/DragonFightManager.java
@@ -125,8 +125,8 @@ public class DragonFightManager
 
 				if (customDragonBattle != null)
 				{
-					// Start the battle with 30 sec delay.
-					this.startBattleTask(dragonFightsObject, customDragonBattle, 20 * 30);
+					// Start the battle with 5 sec delay.
+					this.startBattleTask(dragonFightsObject, customDragonBattle, 20 * 5);
 				}
 			}
 		});


### PR DESCRIPTION
Fixes #1 

There was an issue with local mapping that prevented from updating it to 1.17.1

Also contains a minor fix that starts dragon battles after all islands are loaded.