### PR TITLE
Release 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
 		<java.version>17</java.version>
 		<powermock.version>1.7.4</powermock.version>
 		<!-- More visible way how to change dependency versions -->
-		<spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.19-R0.1-SNAPSHOT</spigot.version>
 		<bentobox.version>1.20.0</bentobox.version>
 		<level.version>2.5.0</level.version>
 		<!-- Revision variable removes warning about dynamic version -->
 		<revision>${build.version}-SNAPSHOT</revision>
 		<!-- This allows to change between versions and snapshots. -->
-		<build.version>1.5.0</build.version>
+		<build.version>1.4.2</build.version>
 		<build.number>-LOCAL</build.number>
 	</properties>
 
@@ -172,7 +172,7 @@
 		<dependency>
 			<groupId>io.github.iltotore</groupId>
 			<artifactId>customentity</artifactId>
-			<version>1.4.0</version>
+			<version>1.4.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -185,6 +185,12 @@
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_18_r2</artifactId>
 			<version>1.4.0</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>lv.id.bonne</groupId>
+			<artifactId>dragonfights-v1_19_r1</artifactId>
+			<version>1.4.1</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- Revision variable removes warning about dynamic version -->
 		<revision>${build.version}-SNAPSHOT</revision>
 		<!-- This allows to change between versions and snapshots. -->
-		<build.version>1.4.1</build.version>
+		<build.version>1.5.0</build.version>
 		<build.number>-LOCAL</build.number>
 	</properties>
 
@@ -133,7 +133,7 @@
 		<dependency>
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
-			<version>22.0.0</version>
+			<version>23.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -172,19 +172,19 @@
 		<dependency>
 			<groupId>io.github.iltotore</groupId>
 			<artifactId>customentity</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_18_r1</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_18_r2</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/lv/id/bonne/dragonfights/config/Settings.java
+++ b/src/main/java/lv/id/bonne/dragonfights/config/Settings.java
@@ -296,6 +296,28 @@ public class Settings implements ConfigObject
 	}
 
 
+	/**
+	 * Gets number of path points.
+	 *
+	 * @return the number of path points
+	 */
+	public int getNumberOfPathPoints()
+	{
+		return numberOfPathPoints;
+	}
+
+
+	/**
+	 * Sets number of path points.
+	 *
+	 * @param numberOfPathPoints the number of path points
+	 */
+	public void setNumberOfPathPoints(int numberOfPathPoints)
+	{
+		this.numberOfPathPoints = Math.max(4, numberOfPathPoints);
+	}
+
+
 	// ---------------------------------------------------------------------
 	// Section: Variables
 	// ---------------------------------------------------------------------
@@ -323,6 +345,12 @@ public class Settings implements ConfigObject
 	@ConfigComment("Default value is 12.")
 	@ConfigEntry(path = "battle.tower-count")
 	private int towerCount = 12;
+
+	@ConfigComment("Number of inner path points for dragon to fly between towers and end trophy generated for the battle.")
+	@ConfigComment("It is recommended to set it to the half of the tower numbers, but never less than 4.")
+	@ConfigComment("Default value is 6. Minimal value is 4.")
+	@ConfigEntry(path = "battle.inner-path-point-count")
+	private int numberOfPathPoints = 6;
 
 	@ConfigComment("Distance from portal till the towers.")
 	@ConfigComment("Default value is 40.")

--- a/src/main/java/lv/id/bonne/dragonfights/entity/BentoBoxEnderDragonRoot.java
+++ b/src/main/java/lv/id/bonne/dragonfights/entity/BentoBoxEnderDragonRoot.java
@@ -91,6 +91,7 @@ public class BentoBoxEnderDragonRoot extends CompositeEntityRoot<EnderDragon>
 	{
 		this.setVersion(ServerVersion.v1_18_1, lv.id.bonne.dragonfights.v1_18_R1.entity.BentoBoxEnderDragonType::new);
 		this.setVersion(ServerVersion.v1_18_2, lv.id.bonne.dragonfights.v1_18_R2.entity.BentoBoxEnderDragonType::new);
+		this.setVersion(ServerVersion.v1_19, lv.id.bonne.dragonfights.v1_19_R1.entity.BentoBoxEnderDragonType::new);
 	}
 }
 

--- a/src/main/java/lv/id/bonne/dragonfights/entity/CustomEntityAPI.java
+++ b/src/main/java/lv/id/bonne/dragonfights/entity/CustomEntityAPI.java
@@ -55,5 +55,6 @@ public class CustomEntityAPI
 	{
 		versions.put(ServerVersion.v1_18_1, lv.id.bonne.dragonfights.v1_18_R1.NMSHandler::new);
 		versions.put(ServerVersion.v1_18_2, lv.id.bonne.dragonfights.v1_18_R2.NMSHandler::new);
+		versions.put(ServerVersion.v1_19, lv.id.bonne.dragonfights.v1_19_R1.NMSHandler::new);
 	}
 }

--- a/src/main/java/lv/id/bonne/dragonfights/listeners/ActivationListener.java
+++ b/src/main/java/lv/id/bonne/dragonfights/listeners/ActivationListener.java
@@ -81,6 +81,13 @@ public class ActivationListener implements Listener
 
 		Island island = islandOptional.get();
 
+		if (island.getCenter().getBlockX() == 0 && island.getCenter().getBlockZ() == 0)
+		{
+			// Dragon should not operate for 0, 0 island because that spot is reserved for
+			// vanilla ender dragon.
+			return;
+		}
+
 		if (island.getRank(User.getInstance(event.getPlayer())) < RanksManager.MEMBER_RANK)
 		{
 			// Only island members should activate the battle.
@@ -181,6 +188,13 @@ public class ActivationListener implements Listener
 		}
 
 		Island island = optionalIsland.get();
+
+		if (island.getCenter().getBlockX() == 0 && island.getCenter().getBlockZ() == 0)
+		{
+			// Dragon should not operate for 0, 0 island because that spot is reserved for
+			// vanilla ender dragon.
+			return;
+		}
 
 		Optional<CustomDragonBattle> optionalBattle =
 			this.addonManager.getDragonBattle(island.getUniqueId());

--- a/src/main/java/lv/id/bonne/dragonfights/managers/DragonFightManager.java
+++ b/src/main/java/lv/id/bonne/dragonfights/managers/DragonFightManager.java
@@ -336,6 +336,7 @@ public class DragonFightManager
 		dragonBattleBuilder.setBattleSeed(this.addon.getSettings().getBattleSeed());
 		dragonBattleBuilder.setNumberOfTowers(this.addon.getSettings().getTowerCount());
 		dragonBattleBuilder.setNumberOfProtectedTowers(this.addon.getSettings().getNumberOfProtectedTowers());
+		dragonBattleBuilder.setNumberOfPathPoints(this.addon.getSettings().getNumberOfPathPoints());
 		dragonBattleBuilder.setMaxTowerHeight(this.addon.getSettings().getMaxTowerHeight());
 		dragonBattleBuilder.setMinTowerHeight(this.addon.getSettings().getMinTowerHeight());
 		dragonBattleBuilder.setDistanceTillTowers(this.addon.getSettings().getTowerDistance());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,10 @@ battle:
   # Number of towers generated for the battle.
   # Default value is 12.
   tower-count: 12
+  # Number of inner path points for dragon to fly between towers and end trophy generated for the battle.
+  # It is recommended to set it to the half of the tower numbers, but never less than 4.
+  # Default value is 6. Minimal value is 4.
+  inner-path-point-count: 6
   # Distance from portal till the towers.
   # Default value is 40.
   tower-distance: 40


### PR DESCRIPTION
This is just a small release for Minecraft 1.19.

It also contains a fix that prevents to start dragon battle at 0,0 location.