### PR TITLE
Release 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
 		<java.version>17</java.version>
 		<powermock.version>1.7.4</powermock.version>
 		<!-- More visible way how to change dependency versions -->
-		<spigot.version>1.19.4-R0.1-SNAPSHOT</spigot.version>
-		<bentobox.version>1.20.0</bentobox.version>
+		<spigot.version>1.20-R0.1-SNAPSHOT</spigot.version>
+		<bentobox.version>1.23.0</bentobox.version>
 		<level.version>2.5.0</level.version>
 		<!-- Revision variable removes warning about dynamic version -->
 		<revision>${build.version}-SNAPSHOT</revision>
 		<!-- This allows to change between versions and snapshots. -->
-		<build.version>1.6.0</build.version>
+		<build.version>1.7.0</build.version>
 		<build.number>-LOCAL</build.number>
 	</properties>
 
@@ -170,19 +170,7 @@
 		<dependency>
 			<groupId>io.github.iltotore</groupId>
 			<artifactId>customentity</artifactId>
-			<version>1.5.0</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>lv.id.bonne</groupId>
-			<artifactId>dragonfights-v1_18_r1</artifactId>
-			<version>1.5.0</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>lv.id.bonne</groupId>
-			<artifactId>dragonfights-v1_18_r2</artifactId>
-			<version>1.5.0</version>
+			<version>1.6.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -201,6 +189,12 @@
 			<groupId>lv.id.bonne</groupId>
 			<artifactId>dragonfights-v1_19_r3</artifactId>
 			<version>1.5.0</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>lv.id.bonne</groupId>
+			<artifactId>dragonfights-v1_20_r1</artifactId>
+			<version>1.6.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/lv/id/bonne/dragonfights/DragonFightsPladdon.java
+++ b/src/main/java/lv/id/bonne/dragonfights/DragonFightsPladdon.java
@@ -7,7 +7,6 @@
 package lv.id.bonne.dragonfights;
 
 
-import org.bukkit.plugin.java.annotation.dependency.Dependency;
 import org.bukkit.plugin.java.annotation.plugin.ApiVersion;
 import org.bukkit.plugin.java.annotation.plugin.Plugin;
 
@@ -16,11 +15,10 @@ import world.bentobox.bentobox.api.addons.Pladdon;
 
 
 /**
- * @author tastybento
+ * @author bonne
  */
-@Plugin(name="Pladdon", version="1.0")
+@Plugin(name="DragonFights", version="1.6.0")
 @ApiVersion(ApiVersion.Target.v1_18)
-@Dependency(value = "BentoBox")
 public class DragonFightsPladdon extends Pladdon
 {
     @Override

--- a/src/main/java/lv/id/bonne/dragonfights/entity/BentoBoxEnderDragonRoot.java
+++ b/src/main/java/lv/id/bonne/dragonfights/entity/BentoBoxEnderDragonRoot.java
@@ -89,11 +89,10 @@ public class BentoBoxEnderDragonRoot extends CompositeEntityRoot<EnderDragon>
 	 * Populate entities based on server version.
 	 */
 	{
-		this.setVersion(ServerVersion.v1_18_1, lv.id.bonne.dragonfights.v1_18_R1.entity.BentoBoxEnderDragonType::new);
-		this.setVersion(ServerVersion.v1_18_2, lv.id.bonne.dragonfights.v1_18_R2.entity.BentoBoxEnderDragonType::new);
 		this.setVersion(ServerVersion.v1_19_1, lv.id.bonne.dragonfights.v1_19_R1.entity.BentoBoxEnderDragonType::new);
 		this.setVersion(ServerVersion.v1_19_2, lv.id.bonne.dragonfights.v1_19_R2.entity.BentoBoxEnderDragonType::new);
 		this.setVersion(ServerVersion.v1_19_3, lv.id.bonne.dragonfights.v1_19_R3.entity.BentoBoxEnderDragonType::new);
+		this.setVersion(ServerVersion.v1_20, lv.id.bonne.dragonfights.v1_20_R1.entity.BentoBoxEnderDragonType::new);
 	}
 }
 

--- a/src/main/java/lv/id/bonne/dragonfights/entity/CustomEntityAPI.java
+++ b/src/main/java/lv/id/bonne/dragonfights/entity/CustomEntityAPI.java
@@ -53,10 +53,9 @@ public class CustomEntityAPI
 	 */
 	static
 	{
-		versions.put(ServerVersion.v1_18_1, lv.id.bonne.dragonfights.v1_18_R1.NMSHandler::new);
-		versions.put(ServerVersion.v1_18_2, lv.id.bonne.dragonfights.v1_18_R2.NMSHandler::new);
 		versions.put(ServerVersion.v1_19_1, lv.id.bonne.dragonfights.v1_19_R1.NMSHandler::new);
 		versions.put(ServerVersion.v1_19_2, lv.id.bonne.dragonfights.v1_19_R2.NMSHandler::new);
 		versions.put(ServerVersion.v1_19_3, lv.id.bonne.dragonfights.v1_19_R3.NMSHandler::new);
+		versions.put(ServerVersion.v1_20, lv.id.bonne.dragonfights.v1_20_R1.NMSHandler::new);
 	}
 }


### PR DESCRIPTION
Adds 1.20 compatibility.

Drops 1.18 compatibility, to match BentoBox supported versions.